### PR TITLE
Url slash

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -20,7 +20,7 @@ class App extends Component {
 			return;
 		}
 
-		fetch(`${Urls.search}/${searchTerm}`)
+		fetch(`${Urls.search}/${searchTerm}/`)
 			.then(results => results.json())
 			.then(jsonResults => this.setState({ 
 				electionJudges: jsonResults,

--- a/src/constants/Urls.js
+++ b/src/constants/Urls.js
@@ -1,5 +1,5 @@
 const Urls = {
-	search: 'https://testservices.baltimorecountymd.gov/api/wufoo/formData',
+	search: 'https://services.baltimorecountymd.gov/api/wufoo/formData',
 	//search: 'http://localhost:1000/api/wufoo/formData',
 };
 


### PR DESCRIPTION
Had to add a slash at the end of the URL for WebAPI.

Invalid: `/this/that/mike@baco.gov `
Valid: `/this/that/mike@baco.gov/`